### PR TITLE
Add parsable directive to `TCP_CHECK` and `HTTP_GET` 

### DIFF
--- a/parser/parser.go.y
+++ b/parser/parser.go.y
@@ -209,6 +209,9 @@ tcp_check_statements: tcp_check_statement tcp_check_statements | tcp_check_state
 tcp_check_statement: { }
 | CONNECT_PORT NUMBER { }
 | CONNECT_TIMEOUT NUMBER { }
+| RETRY NUMBER { }
+| WARMUP NUMBER { }
+| DELAY_BEFORE_RETRY NUMBER { }
 
 http_get_statements: http_get_statement http_get_statements | http_get_statement { }
 

--- a/parser/parser.go.y
+++ b/parser/parser.go.y
@@ -221,6 +221,7 @@ http_get_statement: { }
 | CONNECT_PORT NUMBER { }
 | NB_GET_RETRY NUMBER { }
 | DELAY_BEFORE_RETRY NUMBER { }
+| WARMUP NUMBER { }
 
 url_statements: url_statement url_statements | url_statement { }
 


### PR DESCRIPTION
Keepalived can parse those syntaxes:

```
:
    TCP_CHECK {
        :
        retry 3
        delay_before_retry 3
        warmup 1
        :
    }
:
```

and

```
:
    HTTP_GET {
        :
        warmup 1
        :
    }
:
```

It is undocumented in `keepalived.conf(5)`.

But I checked those directives run correctly.
And you can check those syntaxes is parsable by reading source code.
- https://github.com/acassen/keepalived/blob/951e72059b776f55b25d9b59966d7e1f7139a239/keepalived/check/check_tcp.c#L89-L98
- https://github.com/acassen/keepalived/blob/951e72059b776f55b25d9b59966d7e1f7139a239/keepalived/check/check_http.c#L173
- https://github.com/acassen/keepalived/blob/951e72059b776f55b25d9b59966d7e1f7139a239/keepalived/check/check_http.c#L192

So I added the codes of parse those syntaxes.
