### PR TITLE
Support successive includes

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -285,7 +285,7 @@ func (l *Lexer) run() {
 	for {
 		token, s := l.ctx.scanNextToken()
 
-		if s == "include" {
+		for s == "include" {
 			token, s = l.ctx.scanNextToken()
 
 			if err := l.scanInclude(s); err != nil {


### PR DESCRIPTION
This pull request support successive `include`s, such as:

```
include vrrp.conf
include lb.conf
```
