### PR TITLE
Use x/tools/cmd/goyacc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN := gokc
 all: build
 
 yacc: deps
-	go tool yacc -o parser/parser.go -v parser/parser.output parser/parser.go.y
+	goyacc -o parser/parser.go -v parser/parser.output parser/parser.go.y
 
 build: yacc
 	go build -o $(BIN) ./cmd/...
@@ -25,6 +25,7 @@ gobump:
 	go get github.com/motemen/gobump/cmd/gobump
 
 deps:
+	go get golang.org/x/tools/cmd/goyacc
 	go get -d -v ./...
 
 clean:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -338,11 +338,7 @@ var yyExca = [...]int{
 	-2, 119,
 }
 
-const yyNprod = 296
 const yyPrivate = 57344
-
-var yyTokenNames []string
-var yyStates []string
 
 const yyLast = 532
 


### PR DESCRIPTION
Build failure in Go 1.8, because Go 1.8 removed the `go tool yacc` command.

```
$ make
go get -d -v ./...
go tool yacc -o parser/parser.go -v parser/parser.output parser/parser.go.y
go tool: no such tool "yacc"
Makefile:6: recipe for target 'yacc' failed
make: *** [yacc] Error 2
```

I changed to use `x/tools/cmd/goyacc` instead of `go tool yacc`.

```
$ make
go get golang.org/x/tools/cmd/goyacc
go get -d -v ./...
goyacc -o parser/parser.go -v parser/parser.output parser/parser.go.y
rule ipport:   never reduced
rule any_literal:   never reduced
2 rules never reduced

conflicts: 856 shift/reduce, 118 reduce/reduce
go build -o gokc ./cmd/...
```

Signed-off-by: pandax381 &lt;pandax381@gmail.com&gt;